### PR TITLE
Remove test folder

### DIFF
--- a/cob_gazebo_objects/CMakeLists.txt
+++ b/cob_gazebo_objects/CMakeLists.txt
@@ -6,6 +6,6 @@ find_package(catkin REQUIRED COMPONENTS)
 catkin_package()
 
 ### INSTALL ###
-install(DIRECTORY Media objects test
+install(DIRECTORY Media objects
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
The test folder was removed, so `catkin_make_isolated --install is failing`